### PR TITLE
Exception handling for getting resource from jedis pool and catching …

### DIFF
--- a/JedisManager.cfc
+++ b/JedisManager.cfc
@@ -39,7 +39,15 @@ component {
      * Retrieves a Jedis resource from the Jedis pool.
     */
     private function getJedisResource() {
-        return application.jedisPool.getResource();
+        try {
+            return application.jedisPool.getResource();
+        } catch (Exception e) {
+            throw(
+                type   = "JedisManager.getJedisResource.error",
+                message= "JedisManager error, retrieving a Jedis resource from the Jedis pool: "&e.message,
+                detail = e.detail
+            );
+        }
     }
     
     /**
@@ -70,8 +78,14 @@ component {
             // Use the Jedis resource
             jedis.setex(arguments.cacheKey, arguments.cacheDurationInSeconds, arguments.dataToCache);
         
+        } catch ( "JedisManager.retriveJedis.resource.error" e ) {
+            rethrow;
         } catch (Exception e) {
-            throw(message="JedisManager insert cache error: "&e.message, detail=e.detail);
+            throw(
+                type   = "JedisManager.cacheInsert.error",
+                message= "JedisManager insert cache error: "&e.message,
+                detail = e.detail
+            );
         } finally {
             // Return the Jedis resource to the pool
             returnJedisResource(jedis);
@@ -92,8 +106,14 @@ component {
             var jedis = getJedisResource();
             // Retrieve data from the cache
             return jedis.get(arguments.cacheKey);
+        } catch ( "JedisManager.retriveJedis.resource.error" e ) {
+            rethrow;
         } catch (Exception e) {
-            throw(message="JedisManager get cache error: "&e.message, detail=e.detail);
+            throw(
+                type   = "JedisManager.cacheGet.error",
+                message= "JedisManager get cache error: "&e.message,
+                detail = e.detail
+            );
         } finally {
             // Return the Jedis resource to the pool
             returnJedisResource(jedis);
@@ -115,8 +135,13 @@ component {
 
             // Check key exists in the cache
             return jedis.exists(arguments.cacheKey);
+        } catch ( "JedisManager.retriveJedis.resource.error" e ) {
+            rethrow;
         } catch (Exception e) {
-            throw(message="JedisManager check cache exists error: "&e.message, detail=e.detail);
+            throw(
+                type   = "JedisManager.cacheExists.error",
+                message= "JedisManager check cache exists error: "&e.message,
+                detail = e.detail);
         } finally {
             // Return the Jedis resource to the pool
             returnJedisResource(jedis);

--- a/JedisManager.cfc
+++ b/JedisManager.cfc
@@ -72,9 +72,10 @@ component {
                  numeric cacheDurationInSeconds = variables.cacheDurationInSeconds
     )
     {
+        var jedis = "";
         try {
             // Get a Jedis resource from the pool
-            var jedis = getJedisResource();
+            jedis = getJedisResource();
             // Use the Jedis resource
             jedis.setex(arguments.cacheKey, arguments.cacheDurationInSeconds, arguments.dataToCache);
         
@@ -88,7 +89,7 @@ component {
             );
         } finally {
             // Return the Jedis resource to the pool
-            if(!isNull(jedis)){
+            if(isObject(jedis)){
                 returnJedisResource(jedis);
             }
         }
@@ -103,9 +104,10 @@ component {
         required string cacheKey
     )
     {
+        var jedis = "";
         try {
             // Get a Jedis resource from the pool
-            var jedis = getJedisResource();
+            jedis = getJedisResource();
             // Retrieve data from the cache
             return jedis.get(arguments.cacheKey);
         } catch ( "JedisManager.retriveJedis.resource.error" e ) {
@@ -118,7 +120,7 @@ component {
             );
         } finally {
             // Return the Jedis resource to the pool
-            if(!isNull(jedis)){
+            if(isObject(jedis)){
                 returnJedisResource(jedis);
             }
         }
@@ -133,9 +135,10 @@ component {
         required string cacheKey
     )
     {
+        var jedis = "";
         try {
             // Get a Jedis resource from the pool
-            var jedis = getJedisResource();
+            jedis = getJedisResource();
 
             // Check key exists in the cache
             return jedis.exists(arguments.cacheKey);
@@ -148,7 +151,7 @@ component {
                 detail = e.detail);
         } finally {
             // Return the Jedis resource to the pool
-            if(!isNull(jedis)){
+            if(isObject(jedis)){
                 returnJedisResource(jedis);
             }
             

--- a/JedisManager.cfc
+++ b/JedisManager.cfc
@@ -88,7 +88,7 @@ component {
             );
         } finally {
             // Return the Jedis resource to the pool
-            if(isDefined("jedis")){
+            if(!isNull(jedis)){
                 returnJedisResource(jedis);
             }
         }
@@ -118,7 +118,7 @@ component {
             );
         } finally {
             // Return the Jedis resource to the pool
-            if(isDefined("jedis")){
+            if(!isNull(jedis)){
                 returnJedisResource(jedis);
             }
         }
@@ -148,7 +148,7 @@ component {
                 detail = e.detail);
         } finally {
             // Return the Jedis resource to the pool
-            if(isDefined("jedis")){
+            if(!isNull(jedis)){
                 returnJedisResource(jedis);
             }
             

--- a/JedisManager.cfc
+++ b/JedisManager.cfc
@@ -88,7 +88,9 @@ component {
             );
         } finally {
             // Return the Jedis resource to the pool
-            returnJedisResource(jedis);
+            if(isDefined("jedis")){
+                returnJedisResource(jedis);
+            }
         }
     }
 
@@ -116,7 +118,9 @@ component {
             );
         } finally {
             // Return the Jedis resource to the pool
-            returnJedisResource(jedis);
+            if(isDefined("jedis")){
+                returnJedisResource(jedis);
+            }
         }
     }
 
@@ -144,7 +148,10 @@ component {
                 detail = e.detail);
         } finally {
             // Return the Jedis resource to the pool
-            returnJedisResource(jedis);
+            if(isDefined("jedis")){
+                returnJedisResource(jedis);
+            }
+            
         }
     }
 

--- a/JedisManager.cfc
+++ b/JedisManager.cfc
@@ -161,14 +161,14 @@ component {
     private void function loadSettings() {
         try {
             // Deserialize settings json
-            var jedisSsettings = deserializeJSON(fileRead(expandpath(".")&'/JedisSettings.json'));
+            var jedisSettings = deserializeJSON(fileRead(expandpath(".")&'/JedisSettings.json'));
 
             // Store jedis settings in variables scope
-            variables.jedisServerName        = jedisSsettings.jedisServerName;
-            variables.jedisServerPort        = jedisSsettings.jedisServerPort;
-            variables.jedisMaxTotalpool      = jedisSsettings.jedisMaxTotalpool;
-            variables.jedisMaxIdlePool       = jedisSsettings.jedisMaxIdlePool;
-            variables.cacheDurationInSeconds = jedisSsettings.defaultCacheDurationInSeconds;
+            variables.jedisServerName        = jedisSettings.jedisServerName;
+            variables.jedisServerPort        = jedisSettings.jedisServerPort;
+            variables.jedisMaxTotalpool      = jedisSettings.jedisMaxTotalpool;
+            variables.jedisMaxIdlePool       = jedisSettings.jedisMaxIdlePool;
+            variables.cacheDurationInSeconds = jedisSettings.defaultCacheDurationInSeconds;
 
         } catch (any e) {
             throw(message="JedisManager load settings error: "&e.message, detail=e.detail);


### PR DESCRIPTION
…the same in the other functions where this is called and rethrow
Fixes #1 
Modified the `getJedisResource` function within `JedisManager.cfc` to handle exceptions, and implemented error handling in the calling function where this modified function is invoked. The exception is then rethrown in the latter function.

Inserted an isDefined check for `jedis` within the `finally` block to address scenarios where errors occur in functions like `getJedisResource`, preventing the creation of the 'jedis' variable. Without this check, code within the `finally` block would throw a `jedis not defined` error. By incorporating the isDefined function, potential issues are mitigated, ensuring that the actual error is not overridden by the `jedis not defined` error.