### PR TITLE
Feature/#13 implement user cache operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,4 +60,6 @@ jedisManager.cacheInsert(cacheKey, cacheValue, durationInSeconds);
 
 Refer to `test.cfm` for a sample implementation demonstrating the usage of `JedisManager.cfc` and its caching methods.
 
+Refer to `test1.cfm` for the user-specific cache key implementation utilizing `jedismanager.cfc` and its caching methods. This file generates 500 users and stores user-related IDs and data, which can serve as keys for the cache functions. Additionally, this file can be utilized for conducting load testing operations.
+
 Follow these steps to effectively utilize `JedisManager.cfc` for caching purposes in your ColdFusion application.

--- a/test1.cfm
+++ b/test1.cfm
@@ -1,4 +1,3 @@
-
 <cftry>
     <cfif not structKeyExists(application, "users")>
          <cfset application.users = []>

--- a/test1.cfm
+++ b/test1.cfm
@@ -1,0 +1,32 @@
+
+<cftry>
+    <cfif not structKeyExists(application, "users")>
+         <cfset application.users = []>
+         <cfloop from="1" to="500" index="i">
+            <cfset variables.userDetails = {id=i, data=createUUID()}>
+            <cfset arrayAppend(application.users,variables.userDetails)>
+         </cfloop>
+    </cfif>
+
+    <cfset variables.userSession =  application.users[randRange(1, 500)]>
+    <cfoutput>
+        <cfset variables.redisObj = new JedisManager()>
+        <cfset variables.redisObj.init(reset=true)>
+        
+        <!--- Verify whether data exists in the cache for the specified key and set it with a duration of 30 seconds --->
+        <cfif not variables.redisObj.cacheExists(cacheKey="cacheTest:#variables.userSession.data#")>
+            <p> Cache does not exist, thus data is being set in the cache for the "cacheTest:#variables.userSession.data#" key</p>
+            <cfset variables.redisObj.cacheinsert(cacheKey="cacheTest:#variables.userSession.data#",dataToCache="This is test string",cacheDurationInSeconds=30)>
+        </cfif>
+        <p>The cached data is : #redisObj.cacheget(cacheKey='cacheTest:#variables.userSession.data#')#</p>
+
+         <!--- Delete they key and the data from cache--->
+        <cfset variables.redisObj.cacheClear(cacheKey="cacheTest:#variables.userSession.data#")>
+        <p>Deleted the key "cacheTest:#variables.userSession.data#" from cache</p>
+    </cfoutput>
+    <cfcatch type="any">
+        <cfoutput>
+            <p>We have error in setting or getting the data from the cache : #cfcatch.message#</p>
+        </cfoutput>
+    </cfcatch>
+</cftry>


### PR DESCRIPTION
Fixes #13 

Created `test1.cfm` for the user-specific cache key implementation utilising `jedismanager.cfc` and its caching methods. This file generates 500 users and stores user-related IDs and data, which can serve as keys for the cache functions. Additionally, this file can be utilised for conducting load testing operations.

updated `README` file.