### PR TITLE
Redis Password authentication

### DIFF
--- a/JedisSettings.json
+++ b/JedisSettings.json
@@ -3,5 +3,6 @@
     "jedisServerPort"  : 6379,
     "jedisMaxTotalpool": 100,
     "jedisMaxIdlePool" : 10,
-    "defaultCacheDurationInSeconds" : 20
+    "defaultCacheDurationInSeconds" : 20,
+    "redisPassword" : ""
 }

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ If you're developing on this library, run `box install` to install the local dev
 
 ## Step 2: Set Jedis Configuration Values
 
-Ensure that the necessary Jedis configuration values are set in `JedisSettings.json`. This file contains configuration parameters such as host, port, and other relevant settings required for connecting to the Redis server.
+Ensure that the necessary Jedis configuration values are set in `JedisSettings.json`. This file contains configuration parameters such as host, port, and other relevant settings required for connecting to the Redis server. If authentication is required, specify `redisPassword`; otherwise, leave it blank to connect without authentication.
 
 ## Step 3: Initialize JedisManager.cfc
 


### PR DESCRIPTION
Added  `redisPassword`, to settings..
Modified the JedisPool initialization to include `jedisPassword` if provided
Enabled backward compatibility: if `redisPassword` is not provided, the pool will be created without authentication.
Updated the loadSettings function, to read `redisPassword` from configuration settings.